### PR TITLE
Add version pump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Bump version and publish to ghcr.io
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  tag:
+    name: bump tags
+    outputs:
+      part: ${{ steps.bump_tag.outputs.part }}
+      tag: ${{ steps.bump_tag.outputs.tag }}
+      new_tag: ${{ steps.bump_tag.outputs.new_tag }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '1'
+    - name: Bump version and push tag
+      id: bump_tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch
+
+  push_to_registry:
+    needs: tag
+    if: needs.tag.outputs.part != ''
+    name: Push Docker image to Github Container registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ needs.tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest
+            ${{ github.repository }}:${{ needs.tag.outputs.tag }}
+            ${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read TrackFind's "Contributing Guideline". -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature
- [x] Build system change

### Pull request long description:
This will bump the patch number on each PR merge unless the commit message contains #none.
In order to bump the major or minor version add #major or #minor to the PR message.

#major -> v1.2.3 > 2.0.0
#minor -> v1.2.3 > 1.3.0

If a new tag is created the second part of the action will build a docker image and publish it to the GithHub Container Registry.
The new image can then be pulled by calling `docker pull ghcr.io/uio-bmi/localega-broker:latest`

### Related issues:
#none Do not bump the version for this PR

### Additional information:

### Mentions:
@a-ghanem changed the `ghcr-publish.yml` to `publish.yml` to allow automatic version tagging upon merging to master