### PR TITLE
Added new 'files' queue and more bindings

### DIFF
--- a/private/definitions.json
+++ b/private/definitions.json
@@ -89,6 +89,14 @@
       "auto_delete": false,
       "arguments": {
       }
+    },
+     {
+      "name": "files",
+      "vhost": "VIRTUAL_HOST",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+      }
     }
   ],
   "exchanges": [
@@ -152,6 +160,15 @@
     {
       "source": "sda",
       "vhost": "VIRTUAL_HOST",
+      "destination": "accessionIDs",
+      "destination_type": "queue",
+      "routing_key": "accessionIDs",
+      "arguments": {
+      }
+    },
+    {
+      "source": "sda",
+      "vhost": "VIRTUAL_HOST",
       "destination": "mappings",
       "destination_type": "queue",
       "routing_key": "mapping",
@@ -161,9 +178,27 @@
     {
       "source": "sda",
       "vhost": "VIRTUAL_HOST",
+      "destination": "mappings",
+      "destination_type": "queue",
+      "routing_key": "mappings",
+      "arguments": {
+      }
+    },
+    {
+      "source": "sda",
+      "vhost": "VIRTUAL_HOST",
       "destination": "error",
       "destination_type": "queue",
       "routing_key": "error",
+      "arguments": {
+      }
+    },
+    {
+      "source": "sda",
+      "vhost": "VIRTUAL_HOST",
+      "destination": "files",
+      "destination_type": "queue",
+      "routing_key": "files",
       "arguments": {
       }
     }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read TrackFind's "Contributing Guideline". -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Unit/integration tests
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
Added a new queue named `files` to the `sda` exchange. The MQ-interceptor service will forward all messages from CEGA to this queue so that they can be handled by the SDA intercept service. Also added alternative routing keys for the `accessionIDs` and `mappings` queues which conform with the expectations of the SDA intercept service.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
This commit is related to the "cancel messages" functionality implemented by [PR#498](https://github.com/neicnordic/sda-pipeline/pull/498) in the SDA-pipeline repository and [PR#22](https://github.com/uio-bmi/mq-interceptor/pull/22) in the MQ-interceptor repository.
